### PR TITLE
При $allowGuest=1 не было возможности использовать разные шаблоны комментариев

### DIFF
--- a/core/components/tickets/elements/snippets/snippet.comments.php
+++ b/core/components/tickets/elements/snippets/snippet.comments.php
@@ -14,6 +14,18 @@ if (empty($tplCommentGuest)) {$tplCommentGuest = 'tpl.Tickets.comment.one.guest'
 if (empty($tplLoginToComment)) {$tplLoginToComment = 'tpl.Tickets.comment.login';}
 if (empty($outputSeparator)) {$outputSeparator = "\n";}
 
+/*
+* $anotherTemplat парамет который будет показывать нужны ли разные шаблоны комментариев, если включена возможность комментирования гостями
+* Данный параметр будет работать только если $allowGuest = 1
+* для этого и нужно следующее условие
+*/
+if (empty($allowGuest)) {
+    $anotherTemplate = 0; // если комментирование гостями отключено, то anotherTemplate бессмысленен 
+}
+else{
+    if (empty($anotherTemplate)) {$anotherTemplate = 0;} // если комментирование гостями включено, то определяем нужно ли гостям показывать другой шаблон комментариев , не такой как авторизированным
+}
+
 /** @var Tickets $Tickets */
 $Tickets = $modx->getService('tickets','Tickets',$modx->getOption('tickets.core_path',null,$modx->getOption('core_path').'components/tickets/').'model/tickets/',$scriptProperties);
 $Tickets->initialize($modx->context->key, $scriptProperties);
@@ -131,9 +143,16 @@ if (!empty($rows) && is_array($rows)) {
 		$rows = array_reverse($rows);
 	}
 
-	$tpl = !$thread->get('closed') && ($modx->user->isAuthenticated($modx->context->key) || empty($allowGuest))
-		? $tplCommentAuth
-		: $tplCommentGuest;
+    	if($anotherTemplate == 0){
+        	$tpl = !$thread->get('closed') && ($modx->user->isAuthenticated($modx->context->key) || !empty($allowGuest))
+			? $tplCommentAuth 
+			: $tplCommentGuest;
+	 }
+	 else{
+		 $tpl = !$thread->get('closed') && $modx->user->isAuthenticated($modx->context->key)
+			? $tplCommentAuth 
+			: $tplCommentGuest;
+    }
 	foreach ($rows as $row) {
 		$output[] = $Tickets->templateNode($row, $tpl);
 	}


### PR DESCRIPTION
При $allowGuest=1 не было возможности использовать разные шаблоны комментариев для авторизированных пользователей и гостей. !empty($allowGuest) всегда был тру и поэтому $tpl  всегда равен $tplCommentAuth. Предполагается что если гостям разрешено комментировать, то ответить они могут и им надо показывать тот же самый шаблон что и авторизированным. 
Введение нового параметра добавит возможности использовать разные шаблоны при allowGuest=1, без вмешательство в код сниппета. 
Если же $allowGuest=0, то параметр anotherTemplat не имеет смысла, и поэтому в условии принудительно устанавливаем $anotherTemplate = 0, независимо от того передан ли сниппету anotherTemplate.
