### PR TITLE
Update create.class.php

### DIFF
--- a/core/components/tickets/processors/mgr/ticket/create.class.php
+++ b/core/components/tickets/processors/mgr/ticket/create.class.php
@@ -134,7 +134,7 @@ class TicketCreateProcessor extends modResourceCreateProcessor {
 	public function prepareAlias() {
 		$alias = parent::prepareAlias();
 
-		if ($this->modx->context->key != 'mgr') {
+		if (!$this->modx->config['global_duplicate_uri_check']) {
 			foreach ($this->modx->error->errors as $k => $v) {
 				if ($v['id'] == 'alias' || $v['id'] == 'uri') {
 					unset($this->modx->error->errors[$k]);


### PR DESCRIPTION
Мне кажется это не правильный подход пресекать дубликаты по алиасу, тем более что параметр allow_duplicate_alias уже давно depricated, а uri у нас строиться на основе родителя. К тому же он проверяет дубликаты не зависимо от родителя, а это уже тем более не правильно. Уж лучше вынести эту опцию как проверку системного параметра раздела ticket и, например, назвать его аналогично allow_duplicate_alias.