### PR TITLE
Исправлена генерация uri

### DIFF
--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -439,7 +439,7 @@ class Ticket extends modResource {
 			$pls['vl'][] = '';
 		}
 
-		$uri = rtrim($section->getAliasPath(),'/') .'/'. str_replace($pls['pl'], $pls['vl'], $template);
+		$uri = rtrim($section->getAliasPath($section->get('alias')),'/') .'/'. str_replace($pls['pl'], $pls['vl'], $template);
 		$this->set('uri', $uri);
 		$this->set('uri_override', true);
 		return $uri;


### PR DESCRIPTION
Если не передавать имеющийся `alias` раздела, он будет [сгенерирован заново](https://github.com/modxcms/revolution/blob/master/core/model/modx/modresource.class.php#L868) и может отличаться от существующего, то есть итоговый `uri` тикета не будет включать в себя `uri` раздела.