### PR TITLE
В тикетах не показываются TV

### DIFF
--- a/assets/components/tickets/js/mgr/section/create.js
+++ b/assets/components/tickets/js/mgr/section/create.js
@@ -72,7 +72,7 @@ Ext.extend(Tickets.panel.Section,MODx.panel.Resource,{
 		});
 		if (MODx.config.tvs_below_content == 1) {
 			var tvs = this.getTemplateVariablesPanel(config);
-			tvs.style = 'margin-top: 10px';
+			tvs.style += ';margin-top: 10px;';
 			its.push(tvs);
 		}
 		return its;


### PR DESCRIPTION
Вот после этого коммита https://github.com/modxcms/revolution/commit/e4f5918f88e48bd0c11ad0f9a957aa99ceffe1c9 в тикетах для Modx 2.3 больше не показывались ТВшки, т.к. данная строка убивала установку visible.
Возможно это что-то для 2.2 еще, т.к. марджин этот ни на что не влияет в 2.3 и его перекрывает другой марджин. Т.е. может быть стоит вообще удалить эту строчку...