### PR TITLE
Fixed possible issue with thread latest comment

### DIFF
--- a/core/components/tickets/processors/web/comment/create.class.php
+++ b/core/components/tickets/processors/web/comment/create.class.php
@@ -108,11 +108,13 @@ class TicketCommentCreateProcessor extends modObjectCreateProcessor {
 	 * @return bool
 	 */
 	public function afterSave() {
-		$this->thread->fromArray(array(
-			'comment_last' => $this->object->get('id'),
-			'comment_time' => $this->object->get('createdon'),
-		));
-		$this->thread->save();
+		if ($this->object->get('published')) {
+			$this->thread->fromArray(array(
+				'comment_last' => $this->object->get('id'),
+				'comment_time' => $this->object->get('createdon'),
+			));
+			$this->thread->save();
+		}
 
 		if ($this->guest) {
 			if (!isset($_SESSION['TicketComments'])) {


### PR DESCRIPTION
Мне кажется, что информация о последнем комментарии должна обновляться только в случае опубликованного комментария. Без этого сниппет `TicketLatest` работает не совсем корректно, пропуская некоторые ветки с комментариями, если `comment_last` ссылается на неопубликованное сообщение.