### PR TITLE
Add ability to custom "error" element nesting

### DIFF
--- a/assets/components/tickets/js/web/default.js
+++ b/assets/components/tickets/js/web/default.js
@@ -331,6 +331,7 @@ var Tickets = {
 							for (i in response.data) {
 								field = response.data[i];
 								var elem = $(form).find('[name="' + field.field + '"]').parent().find('.error');
+								var elem = elem.length > 0 ? elem : $(form).find('#' + field.field + '-error');
 								if (elem.length > 0) {
 									elem.text(field.message)
 								}


### PR DESCRIPTION
EQ in foundation zurb in element ["error"](http://foundation.zurb.com/sites/docs/forms.html#help-text)
not nesting in ["input-group"](http://foundation.zurb.com/sites/docs/forms.html#inline-labels-and-buttons)
