### PR TITLE
Добавление события при успешном сохранении коммент

### DIFF
--- a/assets/components/tickets/js/web/default.js
+++ b/assets/components/tickets/js/web/default.js
@@ -317,6 +317,7 @@ var Tickets = {
                 },
                 success: function (response) {
                     $(button).removeAttr('disabled');
+                    $(document).trigger('tickets_complete', response);
                     if (response.success) {
                         Tickets.forms.comment(false);
                         $('#comment-preview-placeholder').html('').hide();


### PR DESCRIPTION
Добавление события при успешном сохранении комментария. Для целей я.метрики к примеру, или [любых других](https://modx.pro/help/7737/) [событий](https://modx.pro/help/6082/).