### PR TITLE
Added events before save and preview comment

### DIFF
--- a/assets/components/tickets/js/web/default.js
+++ b/assets/components/tickets/js/web/default.js
@@ -287,6 +287,7 @@ var Tickets = {
 
     comment: {
         preview: function (form, button) {
+            $(document).trigger('tickets_before_comment_preview', form, button);
             $(form).ajaxSubmit({
                 data: {action: 'comment/preview'},
                 url: TicketsConfig.actionUrl,
@@ -313,6 +314,7 @@ var Tickets = {
         },
 
         save: function (form, button) {
+            $(document).trigger('tickets_before_comment_save', form, button);
             $(form).ajaxSubmit({
                 data: {action: 'comment/save'},
                 url: TicketsConfig.actionUrl,


### PR DESCRIPTION
For example, TinyMCE doesn save it's data to textarea field. You should do this manually, but tickets_comment_preview and tickets_comment_save are executed only after form was sent