### PR TITLE
Исправлено поведение календаря в менеджере Tickets

### DIFF
--- a/assets/components/tickets/js/mgr/ticket/ticket.common.js
+++ b/assets/components/tickets/js/mgr/ticket/ticket.common.js
@@ -158,6 +158,7 @@ Ext.extend(Tickets.panel.Ticket, MODx.panel.Resource, {
                     allowBlank: true,
                     dateFormat: MODx.config.manager_date_format,
                     timeFormat: MODx.config.manager_time_format,
+                    startDay: parseInt(MODx.config.manager_week_start),
                     dateWidth: 120,
                     timeWidth: 120,
                     value: config.record.createdon
@@ -170,6 +171,7 @@ Ext.extend(Tickets.panel.Ticket, MODx.panel.Resource, {
                     allowBlank: true,
                     dateFormat: MODx.config.manager_date_format,
                     timeFormat: MODx.config.manager_time_format,
+                    startDay: parseInt(MODx.config.manager_week_start),
                     dateWidth: 120,
                     timeWidth: 120,
                     value: config.record.publishedon
@@ -182,6 +184,7 @@ Ext.extend(Tickets.panel.Ticket, MODx.panel.Resource, {
                     allowBlank: true,
                     dateFormat: MODx.config.manager_date_format,
                     timeFormat: MODx.config.manager_time_format,
+                    startDay: parseInt(MODx.config.manager_week_start),
                     dateWidth: 120,
                     timeWidth: 120,
                     value: config.record.pub_date
@@ -194,6 +197,7 @@ Ext.extend(Tickets.panel.Ticket, MODx.panel.Resource, {
                     allowBlank: true,
                     dateFormat: MODx.config.manager_date_format,
                     timeFormat: MODx.config.manager_time_format,
+                    startDay: parseInt(MODx.config.manager_week_start),
                     dateWidth: 120,
                     timeWidth: 120,
                     value: config.record.unpub_date


### PR DESCRIPTION
На странице создания/редактирования тикета поля-календари xdatetime не использовали системную настройку MODX manager_week_start (первый день недели).