### PR TITLE
Поиск по не форматированному тексту raw

### DIFF
--- a/core/components/tickets/processors/mgr/comment/getlist.class.php
+++ b/core/components/tickets/processors/mgr/comment/getlist.class.php
@@ -58,6 +58,7 @@ class TicketCommentsGetListProcessor extends modObjectGetListProcessor
             } else {
                 $c->where(array(
                     'TicketComment.text:LIKE' => '%' . $query . '%',
+                    'OR:TicketComment.raw:LIKE' => '%' . $query . '%',
                     'OR:TicketComment.name:LIKE' => '%' . $query . '%',
                     'OR:TicketComment.email:LIKE' => '%' . $query . '%',
                 ));


### PR DESCRIPTION
Данный патч позволяет искать из админки комментарии также и по не форматированному тексту поля TicketComment.raw до прохождения jevix (или других типографов работающих по событию OnBeforeCommentSave).