### PR TITLE
Поиск по ID ветви комментариев

### DIFF
--- a/assets/components/tickets/js/mgr/misc/combos.js
+++ b/assets/components/tickets/js/mgr/misc/combos.js
@@ -11,6 +11,7 @@ Tickets.combo.User = function (config) {
         pageSize: 20,
         url: MODx.config.connector_url,
         typeAhead: false,
+        minChars: 1,
         editable: true,
         allowBlank: false,
         baseParams: {


### PR DESCRIPTION
Поиск по ID ветви комментариев в комбобоксе вывода ветвей комментариев, когда ID состоит из одной цифры, или из двух (по-умолчанию только начиная с 3х цифр начинается поиск в выпадающем списке) и поэтому невозможно найти документ с ID=4 или ID=53, если количество символов в запросе меньше 3. Параметр `minChars: 1,` устанавливает минимальное значение символов для поиска - 1 и поиск работает гораздо удобнее.