### PR TITLE
Добавлена кастомная дата

### DIFF
--- a/core/components/tickets/processors/web/comment/create.class.php
+++ b/core/components/tickets/processors/web/comment/create.class.php
@@ -87,12 +87,17 @@ class TicketCommentCreateProcessor extends modObjectCreateProcessor
         unset($properties['requiredFields']);
 
         // Comment values
+        if($this->getProperty("date")){
+            $date = $this->getProperty("date");
+        } else {
+            $date = date('Y-m-d H:i:s');
+        }
         $ip = $this->modx->request->getClientIp();
         $this->setProperties(array(
             'text' => $text,
             'thread' => $this->thread->id,
             'ip' => $ip['ip'],
-            'createdon' => date('Y-m-d H:i:s'),
+            'createdon' => $date,
             'createdby' => $this->modx->user->isAuthenticated($this->modx->context->key)
                 ? $this->modx->user->id
                 : 0,


### PR DESCRIPTION
Кастомная дата необходима для импорта комментариев в Tickets с сохранением оригинальной даты комментария.
В моем случае происходит дулирование комментариев из вк на сайте. 