### PR TITLE
Fix error "date strftime is not a function"

### DIFF
--- a/assets/components/tickets/js/mgr/misc/utils.js
+++ b/assets/components/tickets/js/mgr/misc/utils.js
@@ -1,7 +1,3 @@
-Ext.Loader.load([
-    MODx.config.assets_url + 'components/tickets/js/mgr/misc/strftime-min-1.3.js'
-]);
-
 Tickets.utils.formatDate = function (string) {
     if (string && string != '0000-00-00 00:00:00' && string != '-1-11-30 00:00:00' && string != 0) {
         var date = /^[0-9]+$/.test(string)

--- a/core/components/tickets/controllers/section/create.class.php
+++ b/core/components/tickets/controllers/section/create.class.php
@@ -44,6 +44,7 @@ class TicketsSectionCreateManagerController extends ResourceCreateManagerControl
             'section' => true,
         ));
         $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/section/create.js');
+        $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/misc/strftime-min-1.3.js');
 
         $ready = array(
             'xtype' => 'tickets-page-section-create',

--- a/core/components/tickets/controllers/section/update.class.php
+++ b/core/components/tickets/controllers/section/update.class.php
@@ -46,6 +46,7 @@ class TicketsSectionUpdateManagerController extends ResourceUpdateManagerControl
             'comments' => true,
         ));
         $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/section/update.js');
+        $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/misc/strftime-min-1.3.js');
 
         $ready = array(
             'xtype' => 'tickets-page-section-update',

--- a/core/components/tickets/controllers/ticket/create.class.php
+++ b/core/components/tickets/controllers/ticket/create.class.php
@@ -59,6 +59,7 @@ class TicketCreateManagerController extends ResourceCreateManagerController
             'ticket' => true,
         ));
         $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/ticket/create.js');
+        $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/misc/strftime-min-1.3.js');
 
         $ready = array(
             'xtype' => 'tickets-page-ticket-create',

--- a/core/components/tickets/controllers/ticket/update.class.php
+++ b/core/components/tickets/controllers/ticket/update.class.php
@@ -51,6 +51,7 @@ class TicketUpdateManagerController extends ResourceUpdateManagerController
             'comments' => true,
         ));
         $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/ticket/update.js');
+        $this->addLastJavascript($Tickets->config['jsUrl'] . 'mgr/misc/strftime-min-1.3.js');
 
         $neighborhood = array();
         if ($this->resource instanceof Ticket) {


### PR DESCRIPTION
Если в менеджере перейти в TicketSection, иногда можно словить ошибку:

```javascript
date.strftime is not a function
```

При этом, пропадает список тикетов. Принцип появления ошибки отследить не смог. Через Chrome (в инкогнито, без расширений и прочего) появляться может 5 раз подряд при обновлении страницы, а может 20 раз не появляться. В Mozilla такой проблемы не встретил (или не дождался пока появится).

Про ошибку писали больше 2 лет назад.

https://modx.pro/help/11562

Наглядный пример:

![fix-error-date-strftime-is-not-a-function](https://file.modx.pro/files/4/b/b/4bb48d2e23e916dc0e8f26163ed7352d.gif)

По всей видимости, в определенный момент, не подгружается библиотека. Решил проблему средствами API MODx, подключаю библиотеку на страницах редактирования и создания TicketSection и Tickets. Повторное подключение библиотеки в js файле убрал.