### PR TITLE
Поиск номера в теле комментария

### DIFF
--- a/core/components/tickets/processors/mgr/comment/getlist.class.php
+++ b/core/components/tickets/processors/mgr/comment/getlist.class.php
@@ -53,6 +53,10 @@ class TicketCommentsGetListProcessor extends modObjectGetListProcessor
                 $c->where(array(
                     'TicketComment.id:=' => $query,
                     'OR:TicketComment.parent:=' => $query,
+                    'OR:TicketComment.text:LIKE' => '%' . $query . '%',
+                    'OR:TicketComment.raw:LIKE' => '%' . $query . '%',
+                    'OR:TicketComment.name:LIKE' => '%' . $query . '%',
+                    'OR:TicketComment.email:LIKE' => '%' . $query . '%',
                 ));
 
             } else {


### PR DESCRIPTION
Поиск номера не только в id и parent id комментария, но и в тексте и остальных полях. Иначе, к примеру, при поиске номера телефона, ничего не найти.