### PR TITLE
Поправлена работа TicketComments с разными объектами

### DIFF
--- a/assets/components/tickets/js/mgr/comment/comments.grid.js
+++ b/assets/components/tickets/js/mgr/comment/comments.grid.js
@@ -255,13 +255,23 @@ Ext.extend(Tickets.grid.Comments, MODx.grid.Grid, {
         var record = typeof(row) != 'undefined'
             ? row.data
             : this.menu.record;
+        
+        var params = {
+            action: 'mgr/thread/get',
+        };
+        if (this.config.threads) {
+            // on page App Tickets
+            params.id = this.config.threads;
+        } else if (this.config.parents) {
+            // on page manage resource
+            params.resource = this.config.parents;
+        } else if (record.resource) {
+            params.resource = record.resource;
+        }
 
         MODx.Ajax.request({
             url: Tickets.config.connector_url,
-            params: {
-                action: 'mgr/thread/get',
-                resource: record.resource,
-            },
+            params: params,
             listeners: {
                 success: {
                     fn: function (r) {


### PR DESCRIPTION
Если использовать сниппет `TicketComments` для реализации чата сообщений в ЛК и указать параметр сниппету `thread` = `user-{$_modx->user.id}`, то при ответе на сообщение из админки он запрашивает в процессоре mgr/thread/get не через `id` трэда, а через `resource`. А т.к. в данной реализации ресурс "Сообщения" для всех юзеров одинаковый, то ответ на комментарий всегда происходит в самый первый трэд.

Данный фикс решает эту проблему.