### PR TITLE
Update ticketqueue.class.php

### DIFF
--- a/core/components/tickets/model/tickets/ticketqueue.class.php
+++ b/core/components/tickets/model/tickets/ticketqueue.class.php
@@ -24,14 +24,15 @@ class TicketQueue extends xPDOSimpleObject
             $this->xpdo->getOption('tickets.mail_from_name', null, $this->xpdo->getOption('site_name'), true)
         );
 
-        if ($user = $this->getOne('User')) {
-            $profile = $user->getOne('Profile');
-            if (!$user->get('active') || $profile->get('blocked')) {
-                return 'This user is not active.';
+        $email = $this->get('email');
+        if (empty($email)) {
+            if ($user = $this->getOne('User')) {
+                $profile = $user->getOne('Profile');
+                if (!$user->get('active') || $profile->get('blocked')) {
+                    return 'This user is not active.';
+                }
+                $email = $profile->get('email');
             }
-            $email = $profile->get('email');
-        } else {
-            $email = $this->get('email');
         }
 
         if (empty($email)) {


### PR DESCRIPTION
Поправлено использование поля `email` у объекта `TicketQueue`. Код был написан так, что оно никогда не используется. Иначе зачем это поле вообще?..