### PR TITLE
Добавлена кастомная дата (#164 rebase)

### DIFF
--- a/core/components/tickets/processors/web/comment/create.class.php
+++ b/core/components/tickets/processors/web/comment/create.class.php
@@ -87,12 +87,17 @@ class TicketCommentCreateProcessor extends modObjectCreateProcessor
         unset($properties['requiredFields']);
 
         // Comment values
+        if ($this->getProperty('date')) {
+            $date = $this->getProperty('date');
+        } else {
+            $date = date('Y-m-d H:i:s');
+        }
         $ip = $this->modx->request->getClientIp();
         $this->setProperties(array(
             'text' => $text,
             'thread' => $this->thread->id,
             'ip' => $ip['ip'],
-            'createdon' => date('Y-m-d H:i:s'),
+            'createdon' => $date,
             'createdby' => $this->modx->user->isAuthenticated($this->modx->context->key)
                 ? $this->modx->user->id
                 : 0,

--- a/core/components/tickets/processors/web/comment/create.class.php
+++ b/core/components/tickets/processors/web/comment/create.class.php
@@ -87,10 +87,24 @@ class TicketCommentCreateProcessor extends modObjectCreateProcessor
         unset($properties['requiredFields']);
 
         // Comment values
-        if ($this->getProperty('date')) {
-            $date = $this->getProperty('date');
-        } else {
-            $date = date('Y-m-d H:i:s');
+        $date = date('Y-m-d H:i:s');
+        $customDate = trim((string)$this->getProperty('date', ''));
+        $this->unsetProperty('date');
+        if ($customDate !== '') {
+            // Import-only: prevent public spoofing of createdon
+            $canSetDate = $this->modx->user->isMember('Administrator');
+            if ($canSetDate) {
+                $dt = \DateTime::createFromFormat('Y-m-d H:i:s', $customDate);
+                $errors = \DateTime::getLastErrors();
+                $valid = $dt instanceof \DateTime
+                    && $dt->format('Y-m-d H:i:s') === $customDate
+                    && empty($errors['warning_count'])
+                    && empty($errors['error_count']);
+                if (!$valid) {
+                    return $this->modx->lexicon('ticket_err_form');
+                }
+                $date = $customDate;
+            }
         }
         $ip = $this->modx->request->getClientIp();
         $this->setProperties(array(


### PR DESCRIPTION
## Summary
- Rebase PR #164 на актуальный `master`
- Позволяет передать `date` в web `comment/create` для импорта с оригинальным `createdon`

## Original
https://github.com/modx-pro/Tickets/pull/164

## Security note
Параметр `date` доступен с фронта без отдельного permission. Перед merge стоит ограничить правами (manager/import) и валидировать формат.

## Test plan
- [ ] Создать комментарий без `date` — `createdon` = now
- [ ] Создать с `date=2019-01-01 12:00:00` — дата сохраняется
- [ ] Решить, нужен ли permission gate