### PR TITLE
Events before comment preview/save (#151 rebase)

### DIFF
--- a/assets/components/tickets/js/web/default.js
+++ b/assets/components/tickets/js/web/default.js
@@ -194,6 +194,7 @@ var Tickets = {
 
     ticket: {
         preview: function (form, button) {
+            $(document).trigger('tickets_before_comment_preview', form, button);
             $(form).ajaxSubmit({
                 data: {action: 'ticket/preview'},
                 url: TicketsConfig.actionUrl,
@@ -250,6 +251,7 @@ var Tickets = {
         },
 
         save: function (form, button) {
+            $(document).trigger('tickets_before_comment_save', form, button);
             var action = 'ticket/';
             switch ($(button).prop('name')) {
                 case 'draft':


### PR DESCRIPTION
## Summary
- Rebase PR #151 на актуальный `master`
- Добавлены `tickets_before_comment_preview` и `tickets_before_comment_save` до `ajaxSubmit` (для TinyMCE и аналогов)

## Original
https://github.com/modx-pro/Tickets/pull/151

## Test plan
- [ ] Подписаться на событие и убедиться, что textarea заполняется до submit
- [ ] Preview/save комментария без кастомного editor работают как раньше