### PR TITLE
Edit description on ticket images (#136 rebase)

### DIFF
--- a/assets/components/tickets/action.php
+++ b/assets/components/tickets/action.php
@@ -115,6 +115,9 @@ switch ($action) {
     case 'ticket/file/delete':
         $response = $Tickets->fileDelete((int)$_POST['id']);
         break;
+    case 'ticket/file/desc':
+        $response = $Tickets->fileDesc((int)$_POST['id'], isset($_POST['desc']) ? $_POST['desc'] : '');
+        break;
     case 'ticket/file/sort':
         $response = $Tickets->fileSort($_POST['rank']);
         break;

--- a/assets/components/tickets/css/web/default.css
+++ b/assets/components/tickets/css/web/default.css
@@ -166,3 +166,4 @@
 #ticket-files-list .ticket-file.deleted .ticket-file-restore {display: inline;}
 
 #ticket-files-list .ticket-ghost-state-highlight {background: lightblue;}
+#ticket-files-list .ticket-file .ticket-file-description {display:block; width:110px; margin:4px 0; font-size:.75em; box-sizing:border-box;}

--- a/assets/components/tickets/js/web/files.js
+++ b/assets/components/tickets/js/web/files.js
@@ -139,6 +139,35 @@ Tickets.StartPlupload = function(comment_id = 0) {
 
 Tickets.StartPlupload();
 
+$(document).on('change', '.ticket-file-description', function () {
+    var $this = $(this);
+    var $form = $this.parents('form');
+    var $parent = $this.parents('.ticket-file');
+    var id = $parent.data('id');
+    var form_key = $form.find('[name="form_key"]').val();
+    var desc = $.trim($this.val());
+
+    $.post(TicketsConfig.actionUrl, {
+        action: 'ticket/file/desc',
+        id: id,
+        desc: desc,
+        form_key: form_key
+    }, function (response) {
+        if (response.success) {
+            if (response.data && response.data.description !== undefined) {
+                $this.val(response.data.description);
+            }
+            var title = $this.val() || $parent.find('.ticket-file-link').attr('title') || '';
+            $parent.find('.ticket-file-template a').attr('title', title);
+            $parent.find('.ticket-file-template img, .ticket-file-image').attr('alt', title);
+        }
+        else {
+            Tickets.Message.error(response.message);
+        }
+    }, 'json');
+    return false;
+});
+
 $(document).on('click', '.ticket-file-delete, .ticket-file-restore', function () {
     var deleted = 'deleted';
     var $this = $(this);

--- a/core/components/tickets/elements/chunks/chunk.form_image.tpl
+++ b/core/components/tickets/elements/chunks/chunk.form_image.tpl
@@ -1,7 +1,7 @@
 <div class="ticket-file[[+deleted]][[+new]]" data-id="[[+id]]">
     <a href="[[+url]]" class="ticket-file-link" title="[[+file]]" target="_blank">
         <div class="ticket-file-image-wrapper">
-            <img src="[[+thumb]]" class="ticket-file-image"/>
+            <img src="[[+thumb]]" class="ticket-file-image" alt="[[+description]]"/>
         </div>
     </a>
     <div class="ticket-file-meta">
@@ -10,11 +10,13 @@
         <br/>
         <a href="#" class="ticket-file-insert">[[%ticket_file_insert]]</a>
         <br/>
+        <input type="text" class="ticket-file-description" value="[[+description]]" placeholder="[[%ticket_file_description]]" maxlength="500" />
+        <br/>
         <span class="ticket-file-size">[[+size]] Kb</span>
     </div>
     <div class="ticket-file-template">
-        <a href="[[+url]]" title="[[+name]]">
-            <img src="[[+thumb]]"/>
+        <a href="[[+url]]" title="[[+description:default=`[[+name]]`]]">
+            <img src="[[+thumb]]" alt="[[+description]]"/>
         </a>
     </div>
 </div>

--- a/core/components/tickets/elements/chunks/chunk.form_image.tpl
+++ b/core/components/tickets/elements/chunks/chunk.form_image.tpl
@@ -15,7 +15,7 @@
         <span class="ticket-file-size">[[+size]] Kb</span>
     </div>
     <div class="ticket-file-template">
-        <a href="[[+url]]" title="[[+description:default=`[[+name]]`]]">
+        <a href="[[+url]]" title="[[+name]]">
             <img src="[[+thumb]]" alt="[[+description]]"/>
         </a>
     </div>

--- a/core/components/tickets/lexicon/de/default.inc.php
+++ b/core/components/tickets/lexicon/de/default.inc.php
@@ -237,6 +237,7 @@ $_lang['ticket_file_select'] = 'Dateien auswählen';
 $_lang['ticket_file_delete'] = 'Löschen';
 $_lang['ticket_file_restore'] = 'Wiederherstellen';
 $_lang['ticket_file_insert'] = 'Link einfügen';
+$_lang['ticket_file_description'] = 'Beschreibung';
 $_lang['ticket_err_source_initialize'] = 'Die Medienquelle kann nicht initialisiert werden';
 $_lang['ticket_err_file_ns'] = 'Die angegebene Datei konnte nicht verarbeitet werden';
 $_lang['ticket_err_file_ext'] = 'Falsche Dateiendung';

--- a/core/components/tickets/lexicon/en/default.inc.php
+++ b/core/components/tickets/lexicon/en/default.inc.php
@@ -250,6 +250,7 @@ $_lang['ticket_file_select'] = 'Select files';
 $_lang['ticket_file_delete'] = 'Delete';
 $_lang['ticket_file_restore'] = 'Restore';
 $_lang['ticket_file_insert'] = 'Insert link';
+$_lang['ticket_file_description'] = 'Description';
 $_lang['ticket_err_source_initialize'] = 'Could not initialize media source';
 $_lang['ticket_err_file_ns'] = 'Could not process specified file';
 $_lang['ticket_err_file_ext'] = 'Wrong file extension';

--- a/core/components/tickets/lexicon/ru/default.inc.php
+++ b/core/components/tickets/lexicon/ru/default.inc.php
@@ -250,6 +250,7 @@ $_lang['ticket_file_select'] = 'Выберите файлы';
 $_lang['ticket_file_delete'] = 'Удалить';
 $_lang['ticket_file_restore'] = 'Восстановить';
 $_lang['ticket_file_insert'] = 'Вставить ссылку';
+$_lang['ticket_file_description'] = 'Описание';
 $_lang['ticket_err_source_initialize'] = 'Не могу инициализировать хранилище файлов';
 $_lang['ticket_err_file_ns'] = 'Не могу обработать указанный файл';
 $_lang['ticket_err_file_ext'] = 'Неправильно расширение файла';

--- a/core/components/tickets/model/tickets/tickets.class.php
+++ b/core/components/tickets/model/tickets/tickets.class.php
@@ -1750,7 +1750,7 @@ class Tickets
             return $this->error($response->getMessage());
         }
 
-        return $this->success();
+        return $this->success('', $response->getObject());
     }
 
 

--- a/core/components/tickets/model/tickets/tickets.class.php
+++ b/core/components/tickets/model/tickets/tickets.class.php
@@ -1729,6 +1729,32 @@ class Tickets
 
 
     /**
+     * Edit description of uploaded file
+     *
+     * @param int $id
+     * @param string $description
+     *
+     * @return array|string
+     */
+    public function fileDesc($id, $description)
+    {
+        if (!$this->authenticated || empty($this->config['allowFiles'])) {
+            return $this->error('ticket_err_access_denied');
+        }
+        /** @var modProcessorResponse $response */
+        $response = $this->runProcessor('web/file/desc', array(
+            'id' => (int)$id,
+            'description' => $description,
+        ));
+        if ($response->isError()) {
+            return $this->error($response->getMessage());
+        }
+
+        return $this->success();
+    }
+
+
+    /**
      * Sort uploaded files
      *
      * @param $rank

--- a/core/components/tickets/processors/web/file/desc.class.php
+++ b/core/components/tickets/processors/web/file/desc.class.php
@@ -25,7 +25,11 @@ class TicketFileDescProcessor extends modObjectProcessor
     public function process()
     {
         $id = (int)$this->getProperty('id');
-        $description = $this->getProperty('description');
+        $description = trim(strip_tags((string)$this->getProperty('description', '')));
+        $charset = $this->modx->getOption('modx_charset', null, 'UTF-8', true);
+        if (mb_strlen($description, $charset) > 500) {
+            $description = mb_substr($description, 0, 500, $charset);
+        }
         /** @var TicketFile $file */
         if (!$file = $this->modx->getObject($this->classKey, $id)) {
             return $this->failure($this->modx->lexicon('ticket_err_file_ns'));
@@ -36,7 +40,7 @@ class TicketFileDescProcessor extends modObjectProcessor
         $file->set('description', $description);
         $file->save();
 
-        return $this->success();
+        return $this->success('', array('description' => $description));
     }
 
 }

--- a/core/components/tickets/processors/web/file/desc.class.php
+++ b/core/components/tickets/processors/web/file/desc.class.php
@@ -1,0 +1,44 @@
+<?php
+
+class TicketFileDescProcessor extends modObjectProcessor
+{
+    public $classKey = 'TicketFile';
+    public $permission = 'ticket_file_upload';
+
+
+    /**
+     * @return bool|null|string
+     */
+    public function initialize()
+    {
+        if (!$this->modx->hasPermission($this->permission)) {
+            return $this->modx->lexicon('access_denied');
+        }
+
+        return true;
+    }
+
+
+    /**
+     * @return array|string
+     */
+    public function process()
+    {
+        $id = (int)$this->getProperty('id');
+        $description = $this->getProperty('description');
+        /** @var TicketFile $file */
+        if (!$file = $this->modx->getObject($this->classKey, $id)) {
+            return $this->failure($this->modx->lexicon('ticket_err_file_ns'));
+        } elseif ($file->createdby != $this->modx->user->id && !$this->modx->user->isMember('Administrator')) {
+            return $this->failure($this->modx->lexicon('ticket_err_file_owner'));
+        }
+
+        $file->set('description', $description);
+        $file->save();
+
+        return $this->success();
+    }
+
+}
+
+return 'TicketFileDescProcessor';


### PR DESCRIPTION
## Summary
- Rebase PR #136 на актуальный `master`
- Endpoint `ticket/file/desc` + processor `web/file/desc`
- `(int)` для id, проверка владельца как в delete

## Original
https://github.com/modx-pro/Tickets/pull/136

## Notes
UI для вызова endpoint в PR нет (как в оригинале). `description` лучше санитизировать / ограничить длину перед merge.

## Test plan
- [ ] `ticket/file/desc` меняет description у своего файла
- [ ] Чужой файл → owner error
- [ ] Гость / без allowFiles → access denied