### PR TITLE
Fix TicketQueue email + blocked check (#179)

### DIFF
--- a/core/components/tickets/model/tickets/ticketqueue.class.php
+++ b/core/components/tickets/model/tickets/ticketqueue.class.php
@@ -24,14 +24,15 @@ class TicketQueue extends xPDOSimpleObject
             $this->xpdo->getOption('tickets.mail_from_name', null, $this->xpdo->getOption('site_name'), true)
         );
 
+        $email = $this->get('email');
         if ($user = $this->getOne('User')) {
             $profile = $user->getOne('Profile');
-            if (!$user->get('active') || $profile->get('blocked')) {
+            if (!$user->get('active') || !$profile || $profile->get('blocked')) {
                 return 'This user is not active.';
             }
-            $email = $profile->get('email');
-        } else {
-            $email = $this->get('email');
+            if (empty($email)) {
+                $email = $profile->get('email');
+            }
         }
 
         if (empty($email)) {


### PR DESCRIPTION
## Summary
- Берёт `email` из `TicketQueue`, иначе из профиля
- Всегда проверяет `active` / `blocked`, даже если email уже в очереди
- Null-check для `Profile`

## Original
https://github.com/modx-pro/Tickets/pull/179

## Test plan
- [ ] Очередь с uid заблокированного пользователя → не шлёт
- [ ] Очередь только с email (без user) → шлёт
- [ ] Очередь с uid + email → шлёт на email очереди, если user активен