### PR TITLE
Поиск номера в теле комментария (#175)

### DIFF
--- a/core/components/tickets/processors/mgr/comment/getlist.class.php
+++ b/core/components/tickets/processors/mgr/comment/getlist.class.php
@@ -49,12 +49,21 @@ class TicketCommentsGetListProcessor extends modObjectGetListProcessor
 
         if ($query = $this->getProperty('query', null)) {
             $query = trim($query);
+            $digits = preg_replace('/\D+/', '', $query);
             if (is_numeric($query)) {
+                // id/parent exact + body search for phone-like numeric queries
                 $c->where(array(
                     'TicketComment.id:=' => $query,
                     'OR:TicketComment.parent:=' => $query,
+                    'OR:TicketComment.text:LIKE' => '%' . $query . '%',
+                    'OR:TicketComment.raw:LIKE' => '%' . $query . '%',
                 ));
-
+            } elseif ($digits !== '' && strlen($digits) >= 7 && preg_match('/^[\d\s\+\-\(\)]+$/', $query)) {
+                // formatted phone: +7 (999) ... → digits only in text/raw
+                $c->where(array(
+                    'TicketComment.text:LIKE' => '%' . $digits . '%',
+                    'OR:TicketComment.raw:LIKE' => '%' . $digits . '%',
+                ));
             } else {
                 $c->where(array(
                     'TicketComment.text:LIKE' => '%' . $query . '%',


### PR DESCRIPTION
## Summary
- Числовой запрос: `id` / `parent` + `text` / `raw` (без `name` / `email`)
- Форматированный телефон (`+7 (999)…`): поиск по цифрам в `text` / `raw`
- Обычный текст: как раньше (`text` / `raw` / `name` / `email`)

## Original
https://github.com/modx-pro/Tickets/pull/175

## Test plan
- [ ] Поиск `123` находит комментарий по id и по тексту с `123`
- [ ] Поиск `+7 999 123-45-67` находит цифры в теле
- [ ] Поиск `ivan@` по-прежнему ищет по email