### PR TITLE
Fix ticket update cache + syncsite_default (#152)

### DIFF
--- a/core/components/tickets/processors/mgr/ticket/update.class.php
+++ b/core/components/tickets/processors/mgr/ticket/update.class.php
@@ -35,6 +35,10 @@ class TicketUpdateProcessor extends modResourceUpdateProcessor
             $res->save();
         }
 
+        $this->setDefaultProperties(array(
+            'syncsite' => $this->modx->getOption('syncsite_default', null, 1),
+        ));
+
         return parent::initialize();
     }
 
@@ -268,7 +272,7 @@ class TicketUpdateProcessor extends modResourceUpdateProcessor
      */
     public function clearCache()
     {
-        $this->object->clearCache();
+        parent::clearCache();
         /** @var TicketsSection $section */
         if ($section = $this->object->getOne('Section')) {
             $section->clearCache();


### PR DESCRIPTION
## Summary
- `syncsite` default из `syncsite_default` (корректный вызов `getOption`)
- `parent::clearCache()` учитывает syncsite ресурса
- Кэш секции чистится всегда (списки тикетов не устаревают)

## Original
https://github.com/modx-pro/Tickets/pull/152

## Test plan
- [ ] Update тикета с syncsite on — кэш ресурса и секции обновлён
- [ ] Update с syncsite off — кэш секции всё равно сброшен