### PR TITLE
fix: open bug issues #187 #186 #183 #180

### DIFF
--- a/core/components/tickets/controllers/section/create.class.php
+++ b/core/components/tickets/controllers/section/create.class.php
@@ -28,7 +28,7 @@ class TicketsSectionCreateManagerController extends ResourceCreateManagerControl
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $this->resourceArray['properties']['tickets'] = $this->resource->getProperties('tickets');

--- a/core/components/tickets/controllers/section/update.class.php
+++ b/core/components/tickets/controllers/section/update.class.php
@@ -28,7 +28,7 @@ class TicketsSectionUpdateManagerController extends ResourceUpdateManagerControl
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $this->resourceArray['properties']['tickets'] = $this->resource->getProperties('tickets');

--- a/core/components/tickets/controllers/ticket/create.class.php
+++ b/core/components/tickets/controllers/ticket/create.class.php
@@ -27,8 +27,11 @@ class TicketCreateManagerController extends ResourceCreateManagerController
     public function getDefaultTemplate()
     {
         $properties = $this->parent->getProperties();
+        if (!empty($properties['template'])) {
+            return (int)$properties['template'];
+        }
 
-        return $properties['template'];
+        return parent::getDefaultTemplate();
     }
 
 
@@ -43,7 +46,7 @@ class TicketCreateManagerController extends ResourceCreateManagerController
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $properties = $this->parent->getProperties('tickets');

--- a/core/components/tickets/controllers/ticket/update.class.php
+++ b/core/components/tickets/controllers/ticket/update.class.php
@@ -36,7 +36,7 @@ class TicketUpdateManagerController extends ResourceUpdateManagerController
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $this->resourceArray['properties']['tickets'] = $this->resource->getProperties('tickets');

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,6 +26,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
+- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
+- `#186` `[[+total]]` в `tplComments` считает загруженные комментарии, а не pdoFetch `totalVar`.
+- `#183` PHP 8: безопасный доступ к `resourceArray['properties']` и `aliasMap` при сохранении тикета.
+- `#180` Устойчивое создание строки в `tickets_totals` при первом обращении к виртуальным полям.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/elements/snippets/snippet.comments.php
+++ b/core/components/tickets/elements/snippets/snippet.comments.php
@@ -147,6 +147,7 @@ $rows = $pdoFetch->run();
 
 // Processing rows
 $output = $commentsThread = null;
+$commentTotal = 0;
 if (!empty($rows) && is_array($rows)) {
     $tmp = array();
     $i = 1;
@@ -155,6 +156,8 @@ if (!empty($rows) && is_array($rows)) {
         $row['idx'] = $i++;
         $tmp[$row['id']] = $row;
     }
+    // pdoFetch totalVar breaks with GROUP BY + Vote/Star joins; count loaded comments
+    $commentTotal = count($tmp);
     $rows = $thread->buildTree($tmp, $depth);
     unset($tmp, $i);
 
@@ -174,7 +177,7 @@ if (!empty($rows) && is_array($rows)) {
 }
 
 $commentsThread = $pdoFetch->getChunk($tplComments, array(
-    'total' => $modx->getPlaceholder($pdoFetch->config['totalVar']),
+    'total' => $commentTotal,
     'comments' => $output,
     'subscribed' => $thread->isSubscribed(),
 ));

--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -134,7 +134,7 @@ class Ticket extends modResource
 
             if (isset($this->_fieldMeta[$k]) && $this->_fieldMeta[$k]['phptype'] == 'string') {
                 $properties = $this->getProperties();
-                if (!$properties['process_tags'] && !in_array($k, $fields)) {
+                if (empty($properties['process_tags']) && !in_array($k, $fields)) {
                     $value = str_replace(
                         array('[', ']', '`', '{', '}'),
                         array('&#91;', '&#93;', '&#96;', '&#123;', '&#125;'),
@@ -201,10 +201,10 @@ class Ticket extends modResource
         $content = parent::get('content');
         $properties = $this->getProperties();
 
-        if (!$properties['disable_jevix']) {
+        if (empty($properties['disable_jevix'])) {
             $content = $this->Jevix($content, false);
         }
-        if (!$properties['process_tags']) {
+        if (empty($properties['process_tags'])) {
             $content = str_replace(
                 array('[', ']', '`', '{', '}'),
                 array('&#91;', '&#93;', '&#96;', '&#123;', '&#125;'),
@@ -321,11 +321,20 @@ class Ticket extends modResource
                 'id' => $this->id,
                 'class' => 'Ticket',
             ), '', true, true);
-            if ($total->save()) {
-                $total->fetchValues();
-                if ($total->isDirty()) {
-                    $total->save();
-                }
+            // Save stub first to break recursion, then fill aggregates
+            if (!$total->save()) {
+                return array(
+                    'comments' => 0,
+                    'views' => 0,
+                    'stars' => 0,
+                    'rating' => 0,
+                    'rating_plus' => 0,
+                    'rating_minus' => 0,
+                );
+            }
+            $total->fetchValues();
+            if ($total->isDirty()) {
+                $total->save();
             }
         }
 
@@ -358,9 +367,10 @@ class Ticket extends modResource
      */
     public function getCommentsCount()
     {
-        $q = $this->xpdo->newQuery('TicketThread', array('name' => 'resource-' . $this->id));
+        // Count comments on all threads of this resource (not only resource-{id})
+        $q = $this->xpdo->newQuery('TicketThread', array('resource' => $this->id));
         $q->leftJoin('TicketComment', 'TicketComment',
-            "`TicketThread`.`id` = `TicketComment`.`thread` AND `TicketComment`.`published` = 1");
+            "`TicketThread`.`id` = `TicketComment`.`thread` AND `TicketComment`.`published` = 1 AND `TicketComment`.`deleted` = 0");
         $q->select('COUNT(`TicketComment`.`id`) as `comments`');
 
         $count = 0;

--- a/core/components/tickets/model/tickets/ticketssection.class.php
+++ b/core/components/tickets/model/tickets/ticketssection.class.php
@@ -231,11 +231,20 @@ class TicketsSection extends modResource
                 'id' => $this->id,
                 'class' => 'TicketsSection',
             ), '', true, true);
-            if ($total->save()) {
-                $total->fetchValues();
-                if ($total->isDirty()) {
-                    $total->save();
-                }
+            if (!$total->save()) {
+                return array(
+                    'comments' => 0,
+                    'views' => 0,
+                    'tickets' => 0,
+                    'stars' => 0,
+                    'rating' => 0,
+                    'rating_plus' => 0,
+                    'rating_minus' => 0,
+                );
+            }
+            $total->fetchValues();
+            if ($total->isDirty()) {
+                $total->save();
             }
         }
 
@@ -338,7 +347,8 @@ class TicketsSection extends modResource
     {
         $q = $this->xpdo->newQuery('Ticket', array('parent' => $this->id, 'published' => 1, 'deleted' => 0));
         $q->leftJoin('TicketThread', 'TicketThread', "`TicketThread`.`resource` = `Ticket`.`id`");
-        $q->leftJoin('TicketComment', 'TicketComment', "`TicketThread`.`id` = `TicketComment`.`thread`");
+        $q->leftJoin('TicketComment', 'TicketComment',
+            "`TicketThread`.`id` = `TicketComment`.`thread` AND `TicketComment`.`published` = 1 AND `TicketComment`.`deleted` = 0");
         $q->select('COUNT(`TicketComment`.`id`) as `comments`');
 
         $count = 0;

--- a/core/components/tickets/processors/mgr/ticket/create.class.php
+++ b/core/components/tickets/processors/mgr/ticket/create.class.php
@@ -222,8 +222,14 @@ class TicketCreateProcessor extends modResourceCreateProcessor
         // Updating resourceMap before OnDocSaveForm event
         $results = $this->modx->cacheManager->generateContext($this->object->context_key,
             array('cache_context_settings' => false));
-        $this->modx->context->resourceMap = $results['resourceMap'];
-        $this->modx->context->aliasMap = $results['aliasMap'];
+        if (is_array($results)) {
+            if (isset($results['resourceMap'])) {
+                $this->modx->context->resourceMap = $results['resourceMap'];
+            }
+            if (isset($results['aliasMap'])) {
+                $this->modx->context->aliasMap = $results['aliasMap'];
+            }
+        }
 
         if ($this->_sendEmails && $this->modx->context->key == 'mgr') {
             $this->sendTicketMails();


### PR DESCRIPTION
Чинит четыре открытых bug-issue в Tickets.

**#187** — `Ticket::getCommentsCount()` считал только thread `resource-{id}`. Теперь считает published/не-deleted комментарии по `TicketThread.resource`, в том числе для кастомных имён вроде `community-{id}`.

**#186** — `[[+total]]` брал pdoFetch `totalVar`, который ломается на `GROUP BY` + join Vote/Star. Считаем число реально загруженных комментариев до `buildTree`.

**#183** — PHP 8 warnings на `resourceArray['properties']` и `aliasMap` портили JSON-ответ mgr при сохранении тикета. Добавлены isset/is_array проверки; `getDefaultTemplate()` не читает отсутствующий `template`. Отдельно: баг Jevix `uniord()` на PHP 8 остаётся в пакете Jevix, не в Tickets.

**#180** — 500 при первом обращении к totals: жёстче обрабатываем insert в `tickets_totals` (stub save → fetchValues → dirty save) для Ticket и TicketsSection.

Fixes #187
Fixes #186
Fixes #183
Fixes #180