### PR TITLE
fix: count ticket comments by thread resource (#187)

### DIFF
--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,6 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
+- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -358,9 +358,10 @@ class Ticket extends modResource
      */
     public function getCommentsCount()
     {
-        $q = $this->xpdo->newQuery('TicketThread', array('name' => 'resource-' . $this->id));
+        // Count comments on all threads of this resource (not only resource-{id})
+        $q = $this->xpdo->newQuery('TicketThread', array('resource' => $this->id));
         $q->leftJoin('TicketComment', 'TicketComment',
-            "`TicketThread`.`id` = `TicketComment`.`thread` AND `TicketComment`.`published` = 1");
+            "`TicketThread`.`id` = `TicketComment`.`thread` AND `TicketComment`.`published` = 1 AND `TicketComment`.`deleted` = 0");
         $q->select('COUNT(`TicketComment`.`id`) as `comments`');
 
         $count = 0;

--- a/core/components/tickets/model/tickets/ticketssection.class.php
+++ b/core/components/tickets/model/tickets/ticketssection.class.php
@@ -338,7 +338,8 @@ class TicketsSection extends modResource
     {
         $q = $this->xpdo->newQuery('Ticket', array('parent' => $this->id, 'published' => 1, 'deleted' => 0));
         $q->leftJoin('TicketThread', 'TicketThread', "`TicketThread`.`resource` = `Ticket`.`id`");
-        $q->leftJoin('TicketComment', 'TicketComment', "`TicketThread`.`id` = `TicketComment`.`thread`");
+        $q->leftJoin('TicketComment', 'TicketComment',
+            "`TicketThread`.`id` = `TicketComment`.`thread` AND `TicketComment`.`published` = 1 AND `TicketComment`.`deleted` = 0");
         $q->select('COUNT(`TicketComment`.`id`) as `comments`');
 
         $count = 0;


### PR DESCRIPTION
## Summary
- `Ticket::getCommentsCount()` считает published/не-deleted комментарии по `TicketThread.resource`, не только `resource-{id}`.
- В `TicketsSection::getCommentsCount()` join с комментариями фильтрует `published = 1` и `deleted = 0`.

Fixes #187

Split from #198.

## Test plan
- [ ] Тикет с thread `resource-{id}`: счётчик комментариев совпадает с числом published комментариев
- [ ] Тикет с кастомным thread name (`community-{id}` и т.п.): комментарии тоже входят в count
- [ ] Deleted комментарии не входят в count
- [ ] Счётчик секции не включает unpublished/deleted комментарии дочерних тикетов