### PR TITLE
fix: use loaded comment count for tplComments total (#186)

### DIFF
--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,6 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
+- `#186` `[[+total]]` в `tplComments` считает загруженные комментарии, а не pdoFetch `totalVar`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#186` `[[+total]]` в `tplComments` считает загруженные комментарии, а не pdoFetch `totalVar`.
+- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/elements/snippets/snippet.comments.php
+++ b/core/components/tickets/elements/snippets/snippet.comments.php
@@ -147,6 +147,7 @@ $rows = $pdoFetch->run();
 
 // Processing rows
 $output = $commentsThread = null;
+$commentTotal = 0;
 if (!empty($rows) && is_array($rows)) {
     $tmp = array();
     $i = 1;
@@ -155,6 +156,8 @@ if (!empty($rows) && is_array($rows)) {
         $row['idx'] = $i++;
         $tmp[$row['id']] = $row;
     }
+    // pdoFetch totalVar breaks with GROUP BY + Vote/Star joins; count loaded comments
+    $commentTotal = count($tmp);
     $rows = $thread->buildTree($tmp, $depth);
     unset($tmp, $i);
 
@@ -174,7 +177,7 @@ if (!empty($rows) && is_array($rows)) {
 }
 
 $commentsThread = $pdoFetch->getChunk($tplComments, array(
-    'total' => $modx->getPlaceholder($pdoFetch->config['totalVar']),
+    'total' => $commentTotal,
     'comments' => $output,
     'subscribed' => $thread->isSubscribed(),
 ));

--- a/core/components/tickets/elements/snippets/snippet.comments.php
+++ b/core/components/tickets/elements/snippets/snippet.comments.php
@@ -156,8 +156,15 @@ if (!empty($rows) && is_array($rows)) {
         $row['idx'] = $i++;
         $tmp[$row['id']] = $row;
     }
-    // pdoFetch totalVar breaks with GROUP BY + Vote/Star joins; count loaded comments
-    $commentTotal = count($tmp);
+    // pdoFetch totalVar breaks with GROUP BY + Vote/Star joins
+    $commentTotal = (int)$thread->get('comments');
+    if ($commentTotal <= 0) {
+        $countWhere = array('thread' => $thread->get('id'), 'deleted' => 0);
+        if (empty($showUnpublished)) {
+            $countWhere['published'] = 1;
+        }
+        $commentTotal = $modx->getCount('TicketComment', $countWhere);
+    }
     $rows = $thread->buildTree($tmp, $depth);
     unset($tmp, $i);
 


### PR DESCRIPTION
## Summary
- `[[+total]]` в `tplComments` берёт число реально загруженных комментариев до `buildTree`.
- Больше не опирается на pdoFetch `totalVar`, который ломается на `GROUP BY` + join Vote/Star.

Fixes #186

Split from #198.

## Test plan
- [ ] `TicketComments` с рейтингами/звёздами: `[[+total]]` равен числу выведенных комментариев
- [ ] Пустой thread: `total` = 0
- [ ] Вложенные комментарии: total считает flat-список до `buildTree`, не узлы дерева