### PR TITLE
fix: harden PHP 8 mgr ticket save paths (#183)

### DIFF
--- a/core/components/tickets/controllers/section/create.class.php
+++ b/core/components/tickets/controllers/section/create.class.php
@@ -28,7 +28,7 @@ class TicketsSectionCreateManagerController extends ResourceCreateManagerControl
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $this->resourceArray['properties']['tickets'] = $this->resource->getProperties('tickets');

--- a/core/components/tickets/controllers/section/update.class.php
+++ b/core/components/tickets/controllers/section/update.class.php
@@ -28,7 +28,7 @@ class TicketsSectionUpdateManagerController extends ResourceUpdateManagerControl
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $this->resourceArray['properties']['tickets'] = $this->resource->getProperties('tickets');

--- a/core/components/tickets/controllers/ticket/create.class.php
+++ b/core/components/tickets/controllers/ticket/create.class.php
@@ -27,8 +27,11 @@ class TicketCreateManagerController extends ResourceCreateManagerController
     public function getDefaultTemplate()
     {
         $properties = $this->parent->getProperties();
+        if (!empty($properties['template'])) {
+            return (int)$properties['template'];
+        }
 
-        return $properties['template'];
+        return parent::getDefaultTemplate();
     }
 
 
@@ -43,7 +46,7 @@ class TicketCreateManagerController extends ResourceCreateManagerController
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $properties = $this->parent->getProperties('tickets');

--- a/core/components/tickets/controllers/ticket/update.class.php
+++ b/core/components/tickets/controllers/ticket/update.class.php
@@ -36,7 +36,7 @@ class TicketUpdateManagerController extends ResourceUpdateManagerController
         parent::loadCustomCssJs();
         $this->head['html'] = $html;
 
-        if (is_null($this->resourceArray['properties'])) {
+        if (!isset($this->resourceArray['properties']) || !is_array($this->resourceArray['properties'])) {
             $this->resourceArray['properties'] = array();
         }
         $this->resourceArray['properties']['tickets'] = $this->resource->getProperties('tickets');

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,6 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
+- `#183` PHP 8: безопасный доступ к `resourceArray['properties']` и `aliasMap` при сохранении тикета.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#183` PHP 8: безопасный доступ к `resourceArray['properties']` и `aliasMap` при сохранении тикета.
+- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -134,7 +134,7 @@ class Ticket extends modResource
 
             if (isset($this->_fieldMeta[$k]) && $this->_fieldMeta[$k]['phptype'] == 'string') {
                 $properties = $this->getProperties();
-                if (!$properties['process_tags'] && !in_array($k, $fields)) {
+                if (empty($properties['process_tags']) && !in_array($k, $fields)) {
                     $value = str_replace(
                         array('[', ']', '`', '{', '}'),
                         array('&#91;', '&#93;', '&#96;', '&#123;', '&#125;'),
@@ -201,10 +201,10 @@ class Ticket extends modResource
         $content = parent::get('content');
         $properties = $this->getProperties();
 
-        if (!$properties['disable_jevix']) {
+        if (empty($properties['disable_jevix'])) {
             $content = $this->Jevix($content, false);
         }
-        if (!$properties['process_tags']) {
+        if (empty($properties['process_tags'])) {
             $content = str_replace(
                 array('[', ']', '`', '{', '}'),
                 array('&#91;', '&#93;', '&#96;', '&#123;', '&#125;'),

--- a/core/components/tickets/processors/mgr/ticket/create.class.php
+++ b/core/components/tickets/processors/mgr/ticket/create.class.php
@@ -222,8 +222,14 @@ class TicketCreateProcessor extends modResourceCreateProcessor
         // Updating resourceMap before OnDocSaveForm event
         $results = $this->modx->cacheManager->generateContext($this->object->context_key,
             array('cache_context_settings' => false));
-        $this->modx->context->resourceMap = $results['resourceMap'];
-        $this->modx->context->aliasMap = $results['aliasMap'];
+        if (is_array($results)) {
+            if (isset($results['resourceMap'])) {
+                $this->modx->context->resourceMap = $results['resourceMap'];
+            }
+            if (isset($results['aliasMap'])) {
+                $this->modx->context->aliasMap = $results['aliasMap'];
+            }
+        }
 
         if ($this->_sendEmails && $this->modx->context->key == 'mgr') {
             $this->sendTicketMails();


### PR DESCRIPTION
## Summary
- Controllers ticket/section create+update: `resourceArray['properties']` через `isset` + `is_array`.
- `getDefaultTemplate()` не читает отсутствующий `template`, иначе `parent::getDefaultTemplate()`.
- Create processor: безопасная запись `resourceMap` / `aliasMap` после `generateContext`.
- `Ticket`: `empty()` вместо прямого доступа к `process_tags` / `disable_jevix`.

Баг Jevix `uniord()` на PHP 8 остаётся в пакете Jevix, не в Tickets.

Fixes #183

Split from #198.

## Test plan
- [ ] PHP 8.0/8.1: создать тикет в mgr без PHP warnings в JSON-ответе
- [ ] PHP 8.0/8.1: обновить тикет в mgr
- [ ] Создать секцию и тикет с пустыми properties у parent
- [ ] Создание тикета в секции без `template` в properties