### PR TITLE
fix: harden tickets_totals stub creation on first access (#180)

### DIFF
--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#180` Устойчивое создание строки в `tickets_totals` при первом обращении к виртуальным полям.
+- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,6 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
+- `#180` Устойчивое создание строки в `tickets_totals` при первом обращении к виртуальным полям.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -315,37 +315,11 @@ class Ticket extends modResource
     protected function _getVirtualFields()
     {
         /** @var TicketTotal $total */
-        if (!$total = $this->getOne('Total')) {
-            $total = $this->xpdo->newObject('TicketTotal');
-            $total->fromArray(array(
-                'id' => $this->id,
-                'class' => 'Ticket',
-            ), '', true, true);
-            // Save stub first to break recursion, then fill aggregates
-            if (!$total->save()) {
-                return array(
-                    'comments' => 0,
-                    'views' => 0,
-                    'stars' => 0,
-                    'rating' => 0,
-                    'rating_plus' => 0,
-                    'rating_minus' => 0,
-                );
-            }
-            $total->fetchValues();
-            if ($total->isDirty()) {
-                $total->save();
-            }
+        if ($total = $this->getOne('Total')) {
+            return $total->get(TicketTotal::fieldsFor('Ticket'));
         }
 
-        return $total->get(array(
-            'comments',
-            'views',
-            'stars',
-            'rating',
-            'rating_plus',
-            'rating_minus',
-        ));
+        return TicketTotal::createAndFetch($this->xpdo, $this->id, 'Ticket');
     }
 
 

--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -321,11 +321,20 @@ class Ticket extends modResource
                 'id' => $this->id,
                 'class' => 'Ticket',
             ), '', true, true);
-            if ($total->save()) {
-                $total->fetchValues();
-                if ($total->isDirty()) {
-                    $total->save();
-                }
+            // Save stub first to break recursion, then fill aggregates
+            if (!$total->save()) {
+                return array(
+                    'comments' => 0,
+                    'views' => 0,
+                    'stars' => 0,
+                    'rating' => 0,
+                    'rating_plus' => 0,
+                    'rating_minus' => 0,
+                );
+            }
+            $total->fetchValues();
+            if ($total->isDirty()) {
+                $total->save();
             }
         }
 

--- a/core/components/tickets/model/tickets/ticketssection.class.php
+++ b/core/components/tickets/model/tickets/ticketssection.class.php
@@ -225,38 +225,11 @@ class TicketsSection extends modResource
     protected function _getVirtualFields()
     {
         /** @var TicketTotal $total */
-        if (!$total = $this->getOne('Total')) {
-            $total = $this->xpdo->newObject('TicketTotal');
-            $total->fromArray(array(
-                'id' => $this->id,
-                'class' => 'TicketsSection',
-            ), '', true, true);
-            if (!$total->save()) {
-                return array(
-                    'comments' => 0,
-                    'views' => 0,
-                    'tickets' => 0,
-                    'stars' => 0,
-                    'rating' => 0,
-                    'rating_plus' => 0,
-                    'rating_minus' => 0,
-                );
-            }
-            $total->fetchValues();
-            if ($total->isDirty()) {
-                $total->save();
-            }
+        if ($total = $this->getOne('Total')) {
+            return $total->get(TicketTotal::fieldsFor('TicketsSection'));
         }
 
-        return $total->get(array(
-            'comments',
-            'views',
-            'tickets',
-            'stars',
-            'rating',
-            'rating_plus',
-            'rating_minus',
-        ));
+        return TicketTotal::createAndFetch($this->xpdo, $this->id, 'TicketsSection');
     }
 
 

--- a/core/components/tickets/model/tickets/ticketssection.class.php
+++ b/core/components/tickets/model/tickets/ticketssection.class.php
@@ -231,11 +231,20 @@ class TicketsSection extends modResource
                 'id' => $this->id,
                 'class' => 'TicketsSection',
             ), '', true, true);
-            if ($total->save()) {
-                $total->fetchValues();
-                if ($total->isDirty()) {
-                    $total->save();
-                }
+            if (!$total->save()) {
+                return array(
+                    'comments' => 0,
+                    'views' => 0,
+                    'tickets' => 0,
+                    'stars' => 0,
+                    'rating' => 0,
+                    'rating_plus' => 0,
+                    'rating_minus' => 0,
+                );
+            }
+            $total->fetchValues();
+            if ($total->isDirty()) {
+                $total->save();
             }
         }
 

--- a/core/components/tickets/model/tickets/tickettotal.class.php
+++ b/core/components/tickets/model/tickets/tickettotal.class.php
@@ -3,6 +3,99 @@
 class TicketTotal extends xPDOObject
 {
     /**
+     * Virtual fields stored for each class.
+     *
+     * @param string $class
+     *
+     * @return array
+     */
+    public static function fieldsFor($class)
+    {
+        switch ($class) {
+            case 'TicketsSection':
+                return array(
+                    'comments',
+                    'views',
+                    'tickets',
+                    'stars',
+                    'rating',
+                    'rating_plus',
+                    'rating_minus',
+                );
+            case 'TicketComment':
+                return array(
+                    'stars',
+                    'rating',
+                );
+            case 'Ticket':
+            default:
+                return array(
+                    'comments',
+                    'views',
+                    'stars',
+                    'rating',
+                    'rating_plus',
+                    'rating_minus',
+                );
+        }
+    }
+
+
+    /**
+     * Zero defaults when a totals row cannot be created.
+     *
+     * @param string $class
+     *
+     * @return array
+     */
+    public static function emptyValues($class)
+    {
+        $values = array();
+        foreach (self::fieldsFor($class) as $field) {
+            $values[$field] = 0;
+        }
+
+        return $values;
+    }
+
+
+    /**
+     * Create stub totals row, fill aggregates, persist dirty values.
+     * Fail-closed on stub insert; log (but still return in-memory values) if the second save fails.
+     *
+     * @param xPDO $xpdo
+     * @param int $id
+     * @param string $class
+     *
+     * @return array
+     */
+    public static function createAndFetch(xPDO $xpdo, $id, $class)
+    {
+        /** @var TicketTotal $total */
+        $total = $xpdo->newObject('TicketTotal');
+        $total->fromArray(array(
+            'id' => (int)$id,
+            'class' => $class,
+        ), '', true, true);
+
+        if (!$total->save()) {
+            $xpdo->log(xPDO::LOG_LEVEL_ERROR,
+                '[Tickets] Could not create TicketTotal stub for ' . $class . '#' . $id);
+
+            return self::emptyValues($class);
+        }
+
+        $total->fetchValues();
+        if ($total->isDirty() && !$total->save()) {
+            $xpdo->log(xPDO::LOG_LEVEL_ERROR,
+                '[Tickets] Could not save TicketTotal aggregates for ' . $class . '#' . $id);
+        }
+
+        return $total->get(self::fieldsFor($class));
+    }
+
+
+    /**
      * Get values from database
      */
     public function fetchValues()


### PR DESCRIPTION
## Summary
- `Ticket::_getVirtualFields` и `TicketsSection::_getVirtualFields`: если stub `save()` падает, возвращаем нули.
- Иначе `fetchValues()` + dirty `save()` после успешного stub.

Fixes #180

Split from #198.

## Test plan
- [ ] Тикет без строки в `tickets_totals`: первый запрос виртуальных полей не даёт 500
- [ ] Секция без totals: то же
- [ ] После первого доступа строка в `tickets_totals` появляется и заполняется
- [ ] Повторный доступ не плодит лишних insert