### PR TITLE
fix(ticket): regenerate alias and uri after duplicate (#174)

### DIFF
--- a/_build/data/transport.plugins.php
+++ b/_build/data/transport.plugins.php
@@ -14,6 +14,7 @@ $tmp = array(
             'OnWebPageComplete',
             'OnEmptyTrash',
             'OnUserSave',
+            'OnResourceDuplicate',
         ),
     ),
 );

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,6 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
+- `#174` После копирования тикета генерируются уникальные `alias` и `uri`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#174` После копирования тикета генерируются уникальные `alias` и `uri`.
+- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -26,7 +26,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 
 - Рекурсия `TicketTotal::save` (`Maximum function nesting level`).
-- `#187` Подсчёт комментариев тикета по `TicketThread.resource`, не только `resource-{id}`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/elements/plugins/plugin.tickets.php
+++ b/core/components/tickets/elements/plugins/plugin.tickets.php
@@ -115,4 +115,21 @@ switch ($modx->event->name) {
         }
         break;
 
+    case 'OnResourceDuplicate':
+        /** @var modResource $newResource */
+        if (empty($newResource) || !is_object($newResource)) {
+            break;
+        }
+        if ($newResource->get('class_key') !== 'Ticket') {
+            break;
+        }
+        /** @var Ticket $ticket */
+        $ticket = ($newResource instanceof Ticket)
+            ? $newResource
+            : $modx->getObject('Ticket', $newResource->get('id'));
+        if ($ticket instanceof Ticket) {
+            $ticket->regenerateAliasUri();
+        }
+        break;
+
 }

--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -468,6 +468,26 @@ class Ticket extends modResource
 
 
     /**
+     * Regenerate unique alias and uri after the resource was duplicated.
+     *
+     * @return bool
+     */
+    public function regenerateAliasUri()
+    {
+        $alias = $this->cleanAlias($this->get('pagetitle'));
+        if ($alias === '') {
+            $alias = 'ticket';
+        }
+        $alias .= '-' . $this->get('id');
+        $this->set('alias', $alias);
+        $this->set('uri', '');
+        $this->set('uri_override', true);
+        $this->setUri($alias);
+
+        return $this->save();
+    }
+
+    /**
      * Build custom uri with respect to section settings
      *
      * @param string $alias

--- a/core/components/tickets/model/tickets/ticket.class.php
+++ b/core/components/tickets/model/tickets/ticket.class.php
@@ -481,8 +481,10 @@ class Ticket extends modResource
         $alias .= '-' . $this->get('id');
         $this->set('alias', $alias);
         $this->set('uri', '');
-        $this->set('uri_override', true);
-        $this->setUri($alias);
+        if ($this->setUri($alias) === false) {
+            $this->set('uri_override', false);
+            $this->set('uri', $alias);
+        }
 
         return $this->save();
     }


### PR DESCRIPTION
После копирования тикета через `modx-window-resource-duplicate` копия сохраняла alias/uri оригинала (или оставляла конфликт). Сохранение падало без подсветки полей.

`OnResourceDuplicate` для `Ticket` вызывает `regenerateAliasUri()`: alias из pagetitle + id, затем `setUri()`.

Fixes #174