### PR TITLE
feat(tickets): comments link to first unread (#33)

### DIFF
--- a/assets/components/tickets/js/web/default.js
+++ b/assets/components/tickets/js/web/default.js
@@ -166,6 +166,19 @@ var Tickets = {
                 $(this).find('#comment-total, .ticket-comments-count').text(count);
             });
 
+            if (window.location.hash === '#comments' || window.location.hash === '#first_unread') {
+                var target = $('#first_unread');
+                if (!target.length) {
+                    target = $('.ticket-comment-new:first');
+                }
+                if (!target.length) {
+                    target = $('#comments');
+                }
+                if (target.length) {
+                    Tickets.utils.goto(target.attr('id') || 'comments');
+                }
+            }
+
             $("#ticketForm.create").sisyphus({
                 excludeFields: $('#ticketForm .disable-sisyphus')
             });

--- a/core/components/tickets/elements/chunks/chunk.comment_one_auth.tpl
+++ b/core/components/tickets/elements/chunks/chunk.comment_one_auth.tpl
@@ -1,5 +1,5 @@
 <li class="ticket-comment[[+comment_new]]" id="comment-[[+id]]" data-parent="[[+parent]]"
-    data-newparent="[[+new_parent]]" data-id="[[+id]]">
+    data-newparent="[[+new_parent]]" data-id="[[+id]]">[[+comment_first_unread]]
     <div class="ticket-comment-body[[+guest]][[+bad]]">
         <div class="ticket-comment-header">
             <div class="ticket-comment-dot-wrapper">
@@ -34,6 +34,7 @@
 <!--tickets_comment_edit_link <a href="#" class="edit">[[%ticket_comment_edit]]</a>-->
 <!--tickets_comment_was_edited <span class="ticket-comment-edited">([[%ticket_comment_was_edited]])</span>-->
 <!--tickets_comment_new  ticket-comment-new-->
+<!--tickets_comment_first_unread <span id="first_unread"></span>-->
 <!--tickets_can_vote  active-->
 <!--tickets_cant_vote  inactive-->
 <!--tickets_rating_positive  positive-->

--- a/core/components/tickets/elements/chunks/chunk.ticket_latest.tpl
+++ b/core/components/tickets/elements/chunks/chunk.ticket_latest.tpl
@@ -9,5 +9,5 @@
     <span class="ticket">
         <a href="[[~[[+id]]]]">[[+pagetitle]]</a>
     </span>
-    <nobr><i class="glyphicon glyphicon-comment"></i> <span class="comments">[[+comments]]</span></nobr>
+    <nobr><a href="[[~[[+id]]]][[+comments_anchor:default=`#comments`]]"><i class="glyphicon glyphicon-comment"></i> <span class="comments">[[+comments]]</span></a></nobr>
 </div>

--- a/core/components/tickets/elements/chunks/chunk.ticket_list_row.tpl
+++ b/core/components/tickets/elements/chunks/chunk.ticket_list_row.tpl
@@ -17,7 +17,7 @@
             &nbsp;&nbsp;
             <i class="glyphicon glyphicon-eye-open"></i> [[+views]]
             &nbsp;&nbsp;
-            <i class="glyphicon glyphicon-comment"></i> [[+comments]]  [[+new_comments]]
+            <a href="[[~[[+id]]]][[+comments_anchor:default=`#comments`]]"><i class="glyphicon glyphicon-comment"></i> [[+comments]]</a>  [[+new_comments]]
         </span>
         <span class="col-md-2 pull-right ticket-rating[[+active]][[+inactive]]">
             <span class="vote plus[[+voted_plus]]" title="[[%ticket_like]]"><i class="glyphicon glyphicon-arrow-up"></i></span>

--- a/core/components/tickets/elements/snippets/snippet.get_tickets.php
+++ b/core/components/tickets/elements/snippets/snippet.get_tickets.php
@@ -212,6 +212,7 @@ if (!empty($rows) && is_array($rows)) {
         } else {
             $row['new_comments'] = '';
         }
+        $row['comments_anchor'] = !empty($row['new_comments']) ? '#first_unread' : '#comments';
 
         // Processing chunk
         $tpl = $pdoFetch->defineChunk($row);

--- a/core/components/tickets/elements/snippets/snippet.get_tickets.php
+++ b/core/components/tickets/elements/snippets/snippet.get_tickets.php
@@ -190,6 +190,7 @@ if (!empty($rows) && is_array($rows)) {
         $row['date_ago'] = $Tickets->dateFormat($row['createdon']);
         $row['idx'] = $pdoFetch->idx++;
         // Processing new comments
+        $row['comments_anchor'] = '#comments';
         if ($Tickets->authenticated && !empty($row['thread'])) {
             $last_view = $pdoFetch->getObject('TicketView', array(
                 'parent' => $row['id'],
@@ -206,13 +207,15 @@ if (!empty($rows) && is_array($rows)) {
                     'createdon:>' => $last_view['timestamp'],
                     'createdby:!=' => $modx->user->id,
                 ));
+                if (!empty($row['new_comments'])) {
+                    $row['comments_anchor'] = '#first_unread';
+                }
             } else {
                 $row['new_comments'] = $row['comments'];
             }
         } else {
             $row['new_comments'] = '';
         }
-        $row['comments_anchor'] = !empty($row['new_comments']) ? '#first_unread' : '#comments';
 
         // Processing chunk
         $tpl = $pdoFetch->defineChunk($row);

--- a/core/components/tickets/model/tickets/tickets.class.php
+++ b/core/components/tickets/model/tickets/tickets.class.php
@@ -10,6 +10,7 @@ class Tickets
     public $authenticated = false;
     private $prepareCommentCustom = null;
     private $last_view = 0;
+    private $first_unread_marked = false;
 
 
     /**
@@ -1038,6 +1039,11 @@ class Tickets
         }
         $node['comment_was_edited'] = (bool)$node['editedon'];
         $node['comment_new'] = $this->authenticated && $node['createdby'] != $this->modx->user->id && $this->last_view > 0 && strtotime($node['createdon']) > $this->last_view;
+        $node['comment_first_unread'] = false;
+        if (!empty($node['comment_new']) && !$this->first_unread_marked) {
+            $node['comment_first_unread'] = true;
+            $this->first_unread_marked = true;
+        }
 
         return $this->getChunk($tpl, $node, $this->config['fastMode']);
     }

--- a/core/components/tickets/model/tickets/tickets.class.php
+++ b/core/components/tickets/model/tickets/tickets.class.php
@@ -10,7 +10,7 @@ class Tickets
     public $authenticated = false;
     private $prepareCommentCustom = null;
     private $last_view = 0;
-    private $first_unread_marked = false;
+    private $first_unread_marked = array();
 
 
     /**
@@ -1040,9 +1040,10 @@ class Tickets
         $node['comment_was_edited'] = (bool)$node['editedon'];
         $node['comment_new'] = $this->authenticated && $node['createdby'] != $this->modx->user->id && $this->last_view > 0 && strtotime($node['createdon']) > $this->last_view;
         $node['comment_first_unread'] = false;
-        if (!empty($node['comment_new']) && !$this->first_unread_marked) {
+        $unreadKey = !empty($node['resource']) ? (int)$node['resource'] : 0;
+        if (!empty($node['comment_new']) && empty($this->first_unread_marked[$unreadKey])) {
             $node['comment_first_unread'] = true;
-            $this->first_unread_marked = true;
+            $this->first_unread_marked[$unreadKey] = true;
         }
 
         return $this->getChunk($tpl, $node, $this->config['fastMode']);


### PR DESCRIPTION
В списке тикетов счётчик комментариев вёл себя как текст без перехода к непрочитанным.

Ссылка ведёт на `#first_unread`, если есть `new_comments`, иначе на `#comments`. Первый unread помечается `<span id=\"first_unread\">`; hash `#comments` тоже скроллит к нему.

Fixes #33