### PR TITLE
fix: harden follow-ups from merged PRs (2026-07-12)

### DIFF
--- a/assets/components/tickets/css/web/default.css
+++ b/assets/components/tickets/css/web/default.css
@@ -60,7 +60,8 @@
 .tickets-message-info  {background-color: black !important;}
 
 /* Panel with spinner */
-#comments-tpanel {width:32px;display: none;position:fixed;right:0;top:50%;margin-top: -16px;}
+/* class (not id): multiple threads may each render a panel */
+.comments-tpanel, #comments-tpanel {width:32px;display: none;position:fixed;right:0;top:50%;margin-top: -16px;}
 
 #tpanel {width:32px;position:fixed;top:50%;opacity:0.5;background: #AAA;}
 #tpanel:hover{opacity:1;}
@@ -71,11 +72,11 @@
 #tpanel .refresh.loading{background:url("../../img/web/loading.gif") no-repeat left top;background-size:32px;}
 #tpanel .new{text-decoration:none;display: block;color:#fff;font-size:12px;padding:0;padding-top:4px;padding-bottom:6px;width:34px;text-align:center;}
 
-#tpanel-refresh {opacity: .5;width: 32px;height: 32px;background-image: url('../../img/web/refresh.gif');background-size: 32px;cursor: pointer;}
-#tpanel-refresh:hover {opacity: 1;}
-#tpanel-refresh.loading {opacity: 1;background-image: url('../../img/web/loading.gif');cursor: default;}
+.tpanel-refresh, #tpanel-refresh {opacity: .5;width: 32px;height: 32px;background-image: url('../../img/web/refresh.gif');background-size: 32px;cursor: pointer;}
+.tpanel-refresh:hover, #tpanel-refresh:hover {opacity: 1;}
+.tpanel-refresh.loading, #tpanel-refresh.loading {opacity: 1;background-image: url('../../img/web/loading.gif');cursor: default;}
 
-#tpanel-new {margin-top: 2px;border-top: solid 1px #efefef;text-align: center;color: darkgreen;cursor: pointer;}
+.tpanel-new, #tpanel-new {margin-top: 2px;border-top: solid 1px #efefef;text-align: center;color: darkgreen;cursor: pointer;}
 
 /* Unseen comment */
 .ticket-comment-new .ticket-comment-header {background-color: #f5f5dc;}

--- a/assets/components/tickets/js/web/default.js
+++ b/assets/components/tickets/js/web/default.js
@@ -194,19 +194,20 @@ var Tickets = {
             });
         });
 
-        // Link to parent comment
-        $('#comments').on('click touchend', '.ticket-comment-up a', function () {
+        // Link to parent comment (scoped to current thread)
+        $(document).on('click touchend', '.comments-thread .ticket-comment-up a', function () {
+            var thread_id = Tickets.threadId(this);
             var id = $(this).data('id');
             var parent = $(this).data('parent');
             if (parent && id) {
                 Tickets.utils.goto('comment-' + parent);
-                $('#comment-' + parent + ' .ticket-comment-down:lt(1)').show().find('a').attr('data-child', id);
+                $(thread_id + ' #comment-' + parent + ' .ticket-comment-down:lt(1)').show().find('a').attr('data-child', id);
             }
             return false;
         });
 
-        // Link to child comment
-        $('#comments').on('click touchend', '.ticket-comment-down a', function () {
+        // Link to child comment (scoped to current thread)
+        $(document).on('click touchend', '.comments-thread .ticket-comment-down a', function () {
             var child = $(this).data('child');
             if (child) {
                 Tickets.utils.goto('comment-' + child);
@@ -218,7 +219,7 @@ var Tickets = {
 
     ticket: {
         preview: function (form, button) {
-            $(document).trigger('tickets_before_comment_preview', form, button);
+            $(document).trigger('tickets_before_ticket_preview', form, button);
             $(form).ajaxSubmit({
                 data: {action: 'ticket/preview'},
                 url: TicketsConfig.actionUrl,
@@ -275,7 +276,7 @@ var Tickets = {
         },
 
         save: function (form, button) {
-            $(document).trigger('tickets_before_comment_save', form, button);
+            $(document).trigger('tickets_before_ticket_save', form, button);
             var action = 'ticket/';
             switch ($(button).prop('name')) {
                 case 'draft':
@@ -360,6 +361,7 @@ var Tickets = {
     comment: {
         preview: function (form, button, thread_id) {
             thread_id = thread_id || Tickets.threadId(form) || '';
+            $(document).trigger('tickets_before_comment_preview', form, button);
             $(form).ajaxSubmit({
                 data: {action: 'comment/preview'},
                 url: TicketsConfig.actionUrl,
@@ -387,6 +389,7 @@ var Tickets = {
 
         save: function (form, button, thread_id) {
             thread_id = thread_id || Tickets.threadId(form) || '';
+            $(document).trigger('tickets_before_comment_save', form, button);
             $(form).ajaxSubmit({
                 data: {action: 'comment/save'},
                 url: TicketsConfig.actionUrl,
@@ -596,7 +599,7 @@ var Tickets = {
                 Tickets.StartPlupload();
             }
 
-            var reply = $(thread_id + ' #comment-' + comment_id + ' > .comment-reply, ' + thread_id + ' #comment-' + comment_id + ' > div > .comment-reply');
+            var reply = $(thread_id + ' #comment-' + comment_id).find('.comment-reply').first();
             form.insertAfter(reply).show();
             $('a', reply).hide();
             reply.parents('.ticket-comment').removeClass('ticket-comment-new');
@@ -669,7 +672,7 @@ var Tickets = {
                         Tickets.StartPlupload(comment_id);
                     }
 
-                    var reply = $(thread_id + ' #comment-' + comment_id + ' > .comment-reply, ' + thread_id + ' #comment-' + comment_id + ' > div > .comment-reply');
+                    var reply = $(thread_id + ' #comment-' + comment_id).find('.comment-reply').first();
                     var time_left = $('.time', form);
 
                     time_left.text('');
@@ -909,10 +912,14 @@ Tickets.threadId = function (el) {
 };
 
 Tickets.tpanel = {
-    wrapper: '.comments-thread #comments-tpanel',
-    refresh: '.comments-thread #tpanel-refresh',
-    new_comments: '.comments-thread #tpanel-new',
+    wrapper: '#comments-tpanel',
+    refresh: '#tpanel-refresh',
+    new_comments: '#tpanel-new',
     class_new: 'ticket-comment-new',
+
+    root: function (thread_id) {
+        return thread_id ? $(thread_id) : $('.comments-thread');
+    },
 
     initialize: function () {
         if (TicketsConfig.tpanel) {
@@ -920,22 +927,25 @@ Tickets.tpanel = {
             this.stop('');
         }
 
-        $(document).on('click', this.refresh, function () {
+        $(document).on('click', '.comments-thread ' + this.refresh, function () {
             var thread_id = Tickets.threadId(this);
-            $('.' + Tickets.tpanel.class_new).removeClass(Tickets.tpanel.class_new);
+            Tickets.tpanel.root(thread_id).find('.' + Tickets.tpanel.class_new).removeClass(Tickets.tpanel.class_new);
             Tickets.comment.getlist(thread_id);
         });
 
-        $(document).on('click', this.new_comments, function () {
+        $(document).on('click', '.comments-thread ' + this.new_comments, function () {
             var thread_id = Tickets.threadId(this);
-            var elem = $(thread_id + ' .' + Tickets.tpanel.class_new + ':first');
+            var elem = Tickets.tpanel.root(thread_id).find('.' + Tickets.tpanel.class_new + ':first');
+            if (!elem.length) {
+                return;
+            }
             $('html, body').animate({
                 scrollTop: elem.offset().top
             }, 1000, 'linear', function () {
                 elem.removeClass(Tickets.tpanel.class_new);
             });
 
-            var count = parseInt($(this).text());
+            var count = parseInt($(this).text(), 10);
             if (count > 1) {
                 $(this).text(count - 1);
             }
@@ -947,19 +957,20 @@ Tickets.tpanel = {
 
     start: function (thread_id) {
         thread_id = thread_id || '';
-        $(thread_id + ' ' + this.refresh).addClass('loading');
+        this.root(thread_id).find(this.refresh).addClass('loading');
     },
 
     stop: function (thread_id) {
         thread_id = thread_id || '';
-        var count = $(thread_id + ' .' + this.class_new).length;
+        var root = this.root(thread_id);
+        var count = root.find('.' + this.class_new).length;
         if (count > 0) {
-            $(thread_id + ' ' + this.new_comments).text(count).show();
+            root.find(this.new_comments).text(count).show();
         }
         else {
-            $(thread_id + ' ' + this.new_comments).hide();
+            root.find(this.new_comments).hide();
         }
-        $(thread_id + ' ' + this.refresh).removeClass('loading');
+        root.find(this.refresh).removeClass('loading');
     }
 
 };

--- a/assets/components/tickets/js/web/default.js
+++ b/assets/components/tickets/js/web/default.js
@@ -912,9 +912,9 @@ Tickets.threadId = function (el) {
 };
 
 Tickets.tpanel = {
-    wrapper: '#comments-tpanel',
-    refresh: '#tpanel-refresh',
-    new_comments: '#tpanel-new',
+    wrapper: '.comments-tpanel',
+    refresh: '.tpanel-refresh',
+    new_comments: '.tpanel-new',
     class_new: 'ticket-comment-new',
 
     root: function (thread_id) {
@@ -923,7 +923,7 @@ Tickets.tpanel = {
 
     initialize: function () {
         if (TicketsConfig.tpanel) {
-            $(this.wrapper).show();
+            this.root('').find(this.wrapper).show();
             this.stop('');
         }
 

--- a/core/components/tickets/elements/chunks/chunk.comment_wrapper.tpl
+++ b/core/components/tickets/elements/chunks/chunk.comment_wrapper.tpl
@@ -13,9 +13,9 @@
         <ol class="comment-list" id="comments">[[+comments]]</ol>
     </div>
 
-    <div id="comments-tpanel">
-        <div id="tpanel-refresh"></div>
-        <div id="tpanel-new"></div>
+    <div class="comments-tpanel">
+        <div class="tpanel-refresh"></div>
+        <div class="tpanel-new"></div>
     </div>
 </div>
 

--- a/core/components/tickets/elements/chunks/chunk.form_image.tpl
+++ b/core/components/tickets/elements/chunks/chunk.form_image.tpl
@@ -1,7 +1,7 @@
 <div class="ticket-file[[+deleted]][[+new]]" data-id="[[+id]]">
     <a href="[[+url]]" class="ticket-file-link" title="[[+file]]" target="_blank">
         <div class="ticket-file-image-wrapper">
-            <img src="[[+thumb]]" class="ticket-file-image" alt="[[+description]]"/>
+            <img src="[[+thumb]]" class="ticket-file-image" alt="[[+description:htmlent]]"/>
         </div>
     </a>
     <div class="ticket-file-meta">
@@ -10,13 +10,13 @@
         <br/>
         <a href="#" class="ticket-file-insert">[[%ticket_file_insert]]</a>
         <br/>
-        <input type="text" class="ticket-file-description" value="[[+description]]" placeholder="[[%ticket_file_description]]" maxlength="500" />
+        <input type="text" class="ticket-file-description" value="[[+description:htmlent]]" placeholder="[[%ticket_file_description]]" maxlength="500" />
         <br/>
         <span class="ticket-file-size">[[+size]] Kb</span>
     </div>
     <div class="ticket-file-template">
         <a href="[[+url]]" title="[[+name]]">
-            <img src="[[+thumb]]" alt="[[+description]]"/>
+            <img src="[[+thumb]]" alt="[[+description:htmlent]]"/>
         </a>
     </div>
 </div>

--- a/core/components/tickets/processors/mgr/comment/getlist.class.php
+++ b/core/components/tickets/processors/mgr/comment/getlist.class.php
@@ -59,11 +59,15 @@ class TicketCommentsGetListProcessor extends modObjectGetListProcessor
                     'OR:TicketComment.raw:LIKE' => '%' . $query . '%',
                 ));
             } elseif ($digits !== '' && strlen($digits) >= 7 && preg_match('/^[\d\s\+\-\(\)]+$/', $query)) {
-                // formatted phone: +7 (999) ... → digits only in text/raw
-                $c->where(array(
-                    'TicketComment.text:LIKE' => '%' . $digits . '%',
-                    'OR:TicketComment.raw:LIKE' => '%' . $digits . '%',
-                ));
+                // Match formatted query and digits-only body variants
+                $escQuery = '%' . str_replace(array('%', '_'), array('\\%', '\\_'), $query) . '%';
+                $escDigits = '%' . str_replace(array('%', '_'), array('\\%', '\\_'), $digits) . '%';
+                $c->where(
+                    '(TicketComment.text LIKE ' . $this->modx->quote($escQuery)
+                    . ' OR TicketComment.raw LIKE ' . $this->modx->quote($escQuery)
+                    . ' OR TicketComment.text LIKE ' . $this->modx->quote($escDigits)
+                    . ' OR TicketComment.raw LIKE ' . $this->modx->quote($escDigits) . ')'
+                );
             } else {
                 $c->where(array(
                     'TicketComment.text:LIKE' => '%' . $query . '%',

--- a/core/components/tickets/processors/mgr/ticket/update.class.php
+++ b/core/components/tickets/processors/mgr/ticket/update.class.php
@@ -273,6 +273,9 @@ class TicketUpdateProcessor extends modResourceUpdateProcessor
     public function clearCache()
     {
         parent::clearCache();
+        if (empty($this->getProperty('syncsite'))) {
+            return;
+        }
         /** @var TicketsSection $section */
         if ($section = $this->object->getOne('Section')) {
             $section->clearCache();

--- a/core/components/tickets/processors/web/comment/create.class.php
+++ b/core/components/tickets/processors/web/comment/create.class.php
@@ -77,8 +77,9 @@ class TicketCommentCreateProcessor extends modObjectCreateProcessor
         $customDate = trim((string)$this->getProperty('date', ''));
         $this->unsetProperty('date');
         if ($customDate !== '') {
-            // Import-only: prevent public spoofing of createdon
-            $canSetDate = $this->modx->user->isMember('Administrator');
+            // Import/mgr only: group name is spoofable on frontend
+            $canSetDate = (bool)$this->modx->user->get('sudo')
+                || $this->modx->user->hasSessionContext('mgr');
             if (!$canSetDate) {
                 return $this->modx->lexicon('ticket_err_access_denied');
             }

--- a/core/components/tickets/processors/web/comment/create.class.php
+++ b/core/components/tickets/processors/web/comment/create.class.php
@@ -72,6 +72,28 @@ class TicketCommentCreateProcessor extends modObjectCreateProcessor
             return $this->modx->lexicon('ticket_comment_err_no_email');
         }
 
+        // Comment values
+        $date = date('Y-m-d H:i:s');
+        $customDate = trim((string)$this->getProperty('date', ''));
+        $this->unsetProperty('date');
+        if ($customDate !== '') {
+            // Import-only: prevent public spoofing of createdon
+            $canSetDate = $this->modx->user->isMember('Administrator');
+            if (!$canSetDate) {
+                return $this->modx->lexicon('ticket_err_access_denied');
+            }
+            $dt = \DateTime::createFromFormat('Y-m-d H:i:s', $customDate);
+            $errors = \DateTime::getLastErrors();
+            $valid = $dt instanceof \DateTime
+                && $dt->format('Y-m-d H:i:s') === $customDate
+                && empty($errors['warning_count'])
+                && empty($errors['error_count']);
+            if (!$valid) {
+                return $this->modx->lexicon('ticket_err_form');
+            }
+            $date = $customDate;
+        }
+
         // Additional properties
         $properties = $this->getProperties();
         $add = array();
@@ -84,28 +106,7 @@ class TicketCommentCreateProcessor extends modObjectCreateProcessor
         if (!$this->getProperty('published')) {
             $add['was_published'] = false;
         }
-        unset($properties['requiredFields']);
-
-        // Comment values
-        $date = date('Y-m-d H:i:s');
-        $customDate = trim((string)$this->getProperty('date', ''));
-        $this->unsetProperty('date');
-        if ($customDate !== '') {
-            // Import-only: prevent public spoofing of createdon
-            $canSetDate = $this->modx->user->isMember('Administrator');
-            if ($canSetDate) {
-                $dt = \DateTime::createFromFormat('Y-m-d H:i:s', $customDate);
-                $errors = \DateTime::getLastErrors();
-                $valid = $dt instanceof \DateTime
-                    && $dt->format('Y-m-d H:i:s') === $customDate
-                    && empty($errors['warning_count'])
-                    && empty($errors['error_count']);
-                if (!$valid) {
-                    return $this->modx->lexicon('ticket_err_form');
-                }
-                $date = $customDate;
-            }
-        }
+        unset($properties['requiredFields'], $add['date']);
         $ip = $this->modx->request->getClientIp();
         $this->setProperties(array(
             'text' => $text,


### PR DESCRIPTION
Fix regressions found in a clean-code / thermo-nuclear review of PRs merged today.

**#190** — ticket preview/save fired `tickets_before_comment_*`; renamed to `tickets_before_ticket_*` and added matching comment events on comment preview/save.

**#193** — tpanel selectors broke under `.comments-thread #tpanel-*`; parent/child nav was bound to global `#comments`. Scoped to the active thread and simplified reply form insertion.

**#192** — image `description` in attributes/value escaped with `:htmlent`.

**#188** — non-admins sending `date` now get `ticket_err_access_denied` instead of silent ignore; `date` is unset before it can land in comment properties.

**#195** — formatted phone search matches both the typed query and digits-only variants in comment body.

**#197** — section `clearCache()` runs only when `syncsite` is enabled.

Refs #188 #190 #192 #193 #195 #197