### PR TITLE
fix: PHP 8.2+ compatibility for TicketFile and mgr dates

### DIFF
--- a/core/components/tickets/docs/changelog.txt
+++ b/core/components/tickets/docs/changelog.txt
@@ -41,6 +41,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Uninstall: очистка CRC→modDocument, таблиц, меню/категории (#172).
 - XSS: `:htmlent` для `description` в чанке изображения.
 - Описание файлов и события ticket/comment разведены после ревью merged PR.
+- PHP 8.2+: `strftime` в mgr comment get → `date`/`strtr`; `TicketFile` — явный `?modMediaSource` и порядок аргументов `makeThumbnail`.
 
 ## [1.13.1] - 2022-04-07
 

--- a/core/components/tickets/model/tickets/ticketfile.class.php
+++ b/core/components/tickets/model/tickets/ticketfile.class.php
@@ -12,11 +12,11 @@ class TicketFile extends xPDOSimpleObject
 
 
     /**
-     * @param modMediaSource $mediaSource
+     * @param modMediaSource|null $mediaSource
      *
      * @return bool|string
      */
-    public function prepareSource(modMediaSource $mediaSource = null)
+    public function prepareSource(?modMediaSource $mediaSource = null)
     {
         if ($mediaSource) {
             $this->mediaSource = $mediaSource;
@@ -37,11 +37,11 @@ class TicketFile extends xPDOSimpleObject
 
 
     /**
-     * @param modMediaSource $mediaSource
+     * @param modMediaSource|null $mediaSource
      *
      * @return bool|string
      */
-    public function generateThumbnails(modMediaSource $mediaSource = null)
+    public function generateThumbnails(?modMediaSource $mediaSource = null)
     {
         if ($this->get('type') != 'image') {
             return true;
@@ -93,7 +93,7 @@ class TicketFile extends xPDOSimpleObject
             $options['name'] = !is_numeric($k)
                 ? $k
                 : 'thumb';
-            if ($image = $this->makeThumbnail($options, $info)) {
+            if ($image = $this->makeThumbnail($info, $options)) {
                 $this->saveThumbnail($image, $options);
             }
         }
@@ -109,19 +109,19 @@ class TicketFile extends xPDOSimpleObject
      *
      * @return bool|string
      */
-    public function generateThumbnail(modMediaSource $mediaSource = null)
+    public function generateThumbnail(?modMediaSource $mediaSource = null)
     {
         return $this->generateThumbnails($mediaSource);
     }
 
 
     /**
-     * @param array $options
      * @param array $info
+     * @param array $options
      *
      * @return bool|null
      */
-    public function makeThumbnail($options = array(), array $info)
+    public function makeThumbnail(array $info, $options = array())
     {
         if (!class_exists('modPhpThumb')) {
             /** @noinspection PhpIncludeInspection */

--- a/core/components/tickets/processors/mgr/comment/get.class.php
+++ b/core/components/tickets/processors/mgr/comment/get.class.php
@@ -25,9 +25,12 @@ class TicketCommentGetProcessor extends modObjectGetProcessor
 
 
     /**
+     * Format a datetime for the manager UI.
+     * tickets.date_format uses strftime tokens (e.g. %d.%m.%y <small>%H:%M</small>).
+     *
      * @param string $date
      *
-     * @return null|string
+     * @return string
      */
     public function formatDate($date = '')
     {
@@ -35,7 +38,30 @@ class TicketCommentGetProcessor extends modObjectGetProcessor
             return $this->modx->lexicon('no');
         }
 
-        return strftime($this->modx->getOption('tickets.date_format'), strtotime($date));
+        $ts = strtotime($date);
+        if ($ts === false) {
+            return $this->modx->lexicon('no');
+        }
+
+        $format = (string)$this->modx->getOption('tickets.date_format');
+
+        return strtr($format, array(
+            '%d' => date('d', $ts),
+            '%e' => date('j', $ts),
+            '%m' => date('m', $ts),
+            '%Y' => date('Y', $ts),
+            '%y' => date('y', $ts),
+            '%H' => date('H', $ts),
+            '%I' => date('h', $ts),
+            '%M' => date('i', $ts),
+            '%S' => date('s', $ts),
+            '%p' => date('A', $ts),
+            '%P' => date('a', $ts),
+            '%B' => date('F', $ts),
+            '%b' => date('M', $ts),
+            '%A' => date('l', $ts),
+            '%a' => date('D', $ts),
+        ));
     }
 
 }


### PR DESCRIPTION
Replace deprecated/removed `strftime()` in the manager comment get processor and fix PHP 8.4 deprecations on `TicketFile`.

`tickets.date_format` still uses strftime-style tokens (including HTML wrappers like `<small>`), so formatting maps those tokens via `strtr` + `date()` instead of switching the setting to PHP `date()` format. `TicketFile` now uses explicit `?modMediaSource` and reorders `makeThumbnail(array $info, $options = array())` so optional parameters are no longer before required ones.

Verified with `php -l` and loading `TicketFile` under PHP 8.4.17 (no remaining signature deprecations from these methods).